### PR TITLE
Add maximum memory limit to lvdconverter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,11 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}
 message(STATUS ${OpenMP_EXE_LINKER_FLAGS})
 endif()
 
+if (UNIX AND NOT APPLE)
+  # link dl for linux
+  link_libraries(dl)
+endif()
+
 add_subdirectory("src")
 
 add_subdirectory("guibinding")

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -3,6 +3,10 @@ aux_source_directory(. COMMON_SRC)
 
 file(GLOB COMMON_INC "*.h")
 
+if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
+  # must compile with -fPIC
+  add_compile_options(-fPIC)
+endif()
 add_library(common ${VM_SHARED_OR_STATIC})
 target_sources(common PRIVATE ${COMMON_SRC})
 target_include_directories(common PRIVATE "${CMAKE_SOURCE_DIR}/lib/3rdparty")

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -13,55 +13,28 @@
 
 #include <memory>
 
-
 namespace ysl
 {
 
 	class Object;
 
 	template<typename Ty>
-	Ty* Object_Dynamic_Cast(Object * obj)
-	{
-		if (obj == nullptr)
-			return nullptr;
-		return Ty::_ms_RttiType.DerivedFrom(obj->GetRtti()) || obj->GetRtti().DerivedFrom(Ty::_ms_RttiType) ? static_cast<Ty*>(obj) : nullptr;
-	}
+	Ty* Object_Dynamic_Cast(Object * obj);
 
 	template<typename Ty>
-	const Ty* Object_Dynamic_Cast(const Object * obj)
-	{
-		if (obj == nullptr)
-			return nullptr;
-		return Ty::_ms_RttiType == (obj->GetRtti()) ? (Ty*)(obj) : nullptr;
-	}
+	const Ty* Object_Dynamic_Cast(const Object * obj);
 
 	template<typename Ty>
-	Ty * Object_Static_Cast(Object * obj)
-	{
-		return static_cast<Ty>(obj);
-	}
+	Ty * Object_Static_Cast(Object * obj);
 
 	template<typename Ty>
-	const Ty * Object_Static_Cast(const Object * obj)
-	{
-		return static_cast<Ty>(obj);
-	}
-
-	//template<typename Ty>
+	const Ty * Object_Static_Cast(const Object * obj);
 
 	template<typename Ty>
-	std::shared_ptr<Ty> Shared_Object_Dynamic_Cast(const std::shared_ptr<Object> &obj)
-	{
-		if (obj == nullptr)
-			return nullptr;
-		return Ty::_ms_RttiType == obj->GetRtti() ? std::static_pointer_cast<Ty>(obj) : nullptr;
-	}
+	std::shared_ptr<Ty> Shared_Object_Dynamic_Cast(const std::shared_ptr<Object> &obj);
 
 	template<typename Ty>
-	std::shared_ptr<Ty> Shared_Object_Static_Cast(const std::shared_ptr<Object> & obj)
-	{
-		return std::static_pointer_cast<Ty>(obj);
-	}
+	std::shared_ptr<Ty> Shared_Object_Static_Cast(const std::shared_ptr<Object> & obj);
 
 
 }

--- a/src/common/geometry.h
+++ b/src/common/geometry.h
@@ -1368,8 +1368,8 @@ namespace ysl
 		Point3<T> min;
 		Point3<T> max;
 	
-		constexpr Bound3():min(MAX_Float_VALUE, MAX_Float_VALUE, MAX_Float_VALUE),
-			max(LOWEST_Float_VALUE, LOWEST_Float_VALUE, LOWEST_Float_VALUE)
+		constexpr Bound3():min(std::numeric_limits<T>::max(), std::numeric_limits<T>::max(), std::numeric_limits<T>::max()),
+						   max(std::numeric_limits<T>::lowest(), std::numeric_limits<T>::lowest(), std::numeric_limits<T>::lowest())
 		{
 		};
 

--- a/src/common/largevolumecache.cpp
+++ b/src/common/largevolumecache.cpp
@@ -2,7 +2,6 @@
 #include "largevolumecache.h"
 #include <iostream>
 #include <cassert>
-#include <combaseapi.h>
 #include "error.h"
 #include "cachepolicy.h"
 #include <rapidjson/document.h>

--- a/src/common/library.cpp
+++ b/src/common/library.cpp
@@ -42,7 +42,8 @@ namespace ysl
 #else
 #if defined(__MACOSX__) || defined(__APPLE__)
 		fullName = "lib" + name + ".dylib";		// mac extension
-#else defined(__linux__)
+#else
+// #elseif defined(__linux__)
 		fullName = "lib" + name + ".so";			// linux extension
 #endif	/*defined(__MACOSX__) || defined(__APPLE__)*/
 		lib = dlopen(fullName.c_str(), RTLD_NOW | RTLD_GLOBAL);

--- a/src/common/lineararray.h
+++ b/src/common/lineararray.h
@@ -76,7 +76,7 @@ namespace ysl
 
 		const char & operator()(int x)const
 		{
-			return data[x];
+			return reinterpret_cast<const char &>(data[x]);
 		}
 
 		void SetLocalData(const void* data, size_t bytes)

--- a/src/common/lvdconverter.h
+++ b/src/common/lvdconverter.h
@@ -4,6 +4,8 @@
 
 #include <cstring>
 #include <fstream>
+#include <tuple>
+#include <atomic>
 
 #include "geometry.h"
 #include "numeric.h"
@@ -12,787 +14,382 @@
 #include "libraryloader.h"
 #include "timer.h"
 #include "error.h"
-#include <atomic>
 #include "threadpool.h"
 #include "rawreader.h"
-#include <omp.h>
 
 namespace ysl
 {
+class LVDFileTraits
+{
+public:
+	using MagicNumber_t = int;
+	using DimensionSize_t = int;
+	using LogBlockSize_t = int;
+	using BoundarySize_t = int;
+	static constexpr int HeaderSize = 24;
+	static constexpr int MagicNumber = 277536;
+};
 
-	class LVDFileTraits
-	{
-	public:
-		using MagicNumber_t = int;
-		using DimensionSize_t = int;
-		using LogBlockSize_t = int;
-		using BoundarySize_t = int;
-		static constexpr int HeaderSize = 24;
-		static constexpr int MagicNumber = 277536;
-	};
+template <int nLogBlockSize, typename LVDTraits = LVDFileTraits>
+class RawToLVDConverterEx
+{
+	using RawType = unsigned char;
+	//int g_xOffset, g_yOffset, g_zOffset;
+	int g_xSize, g_ySize, g_zSize;
+	int m_step;
+	int g_xBlockSize, g_yBlockSize, g_zBlockSize;
+	RawType g_emptyValue = 0;
+	std::size_t rawPointerOffset;
 
-	template<int nLogBlockSize, typename LVDTraits = LVDFileTraits>
-	class RawToLVDConverter
-	{
-		using RawType = unsigned char;
-		//int g_xOffset, g_yOffset, g_zOffset;
-		int g_xSize, g_ySize, g_zSize;
-		int m_step;
-		int g_xBlockSize, g_yBlockSize, g_zBlockSize;
-		RawType g_emptyValue = 0;
-		std::size_t rawPointerOffset;
+	std::ifstream m_rawFile;
+	std::ofstream m_lvdFile;
 
+	ysl::Vector3i m_lvdDataSize;
+	ysl::Vector3i m_blockDimension;
 
+	std::unique_ptr<RawType[]> m_rawBuf;
+	std::shared_ptr<ysl::IPluginFileMap> lvdIO;
+	unsigned char *lvdPtr;
+	const int m_padding;
+	static constexpr auto blockSize = 1 << nLogBlockSize;
+	std::string inFileName;
 
+public:
+	RawToLVDConverterEx( const std::string &fileName,
+						 int xSize,
+						 int ySize,
+						 int zSize,
+						 int padding,
+						 const std::string &outFileName,
+						 std::size_t offset = 0 );
+	auto DimensionInData() const { return m_lvdDataSize; }
+	auto DimensionInBlock() const { return m_blockDimension; }
+	void setBoundaryValue( RawType value ) { g_emptyValue = value; }
+	bool convert( std::size_t suggestMemGb = 128 );
+	bool save();
+};
 
-		void getData(RawType* dest,
-			const RawType* src,
-			size_t width,
-			size_t height,
-			size_t depth,
-			size_t xb,
-			size_t yb,
-			size_t zb) const;
-
-		static void GetData(RawType * dest,
-			const RawType * src, int width, int height, int depth,
-			int w,
-			int h,
-			int d,
-			int xb,
-			int yb,
-			int zb,
-			int xbegin,
-			int ybegin,
-			int cbegin,
-			int xstep,
-			int ystep,
-			int zstep,
-			RawType fill);
-
-
-		std::ifstream m_rawFile;
-		std::ofstream m_lvdFile;
-
-
-		ysl::Vector3i m_dataSize;
-		ysl::Vector3i m_blockDimension;
-
-		//std::unique_ptr<RawType[]> m_rawBuf;
-		std::shared_ptr<ysl::IPluginFileMap> rawIO;
-		unsigned char * rawPtr;
-
-		//std::unique_ptr<RawType[]> m_lvdBuf;
-		std::shared_ptr<ysl::IPluginFileMap> lvdIO;
-		unsigned char * lvdPtr;
-
-		const int m_padding;
-		static constexpr auto blockSize = 1 << nLogBlockSize;
-
-	public:
-		RawToLVDConverter(const std::string& fileName, int xSize, int ySize, int zSize, int repeat, const std::string & outFileName, std::size_t offset = 0);
-		auto DimensionInData()const { return m_dataSize; }
-		auto DimensionInBlock()const { return m_blockDimension; }
-		void setBoundaryValue(RawType value) { g_emptyValue = value; }
-		bool convert();
-		bool convertMultithread();
-		bool save(const std::string& fileName);
-
-	};
-
-	template <int nLogBlockSize, typename LVDTraits>
-	void RawToLVDConverter<nLogBlockSize, LVDTraits>::getData(RawType* dest,
-		const RawType* src,
-		size_t width,
-		size_t height,
-		size_t depth,
-		size_t xb,
-		size_t yb,
-		size_t zb) const
-	{
-		//#pragma omp parallel for
-
-		for (int z = 0; z < depth; z++)
-			for (int y = 0; y < height; y++)
-				for (int x = 0; x < width; x++)
-				{
-					const int xOffset = -m_padding + xb * m_step;
-					const int yOffset = -m_padding + yb * m_step;
-					const int zOffset = -m_padding + zb * m_step;
-					const int gx = x + xOffset, gy = y + yOffset, gz = z + zOffset;
-					const size_t blockIndex = x + y * g_xBlockSize + z * g_xBlockSize * g_yBlockSize;
-					if (gx >= 0 && gx < g_xSize && gy >= 0 && gy < g_ySize && gz >= 0 && gz < g_zSize)
-					{
-						const size_t linearIndex = (gx)+(gy)* std::size_t(g_xSize) + (gz)* g_xSize * std::size_t(
-							g_ySize);
-						*(dest + blockIndex) = *(src + linearIndex);
-					}
-					else
-					{
-						*(dest + blockIndex) = g_emptyValue;
-					}
-				}
+template <int nLogBlockSize, typename LVDTraits>
+RawToLVDConverterEx<nLogBlockSize, LVDTraits>::RawToLVDConverterEx( const std::string &fileName,
+																	int xSize,
+																	int ySize,
+																	int zSize,
+																	int padding,
+																	const std::string &outFileName,
+																	std::size_t offset ) :
+  g_xSize( xSize ),
+  g_ySize( ySize ),
+  g_zSize( zSize ),
+  g_emptyValue( 0 ),
+  m_padding( padding ),
+  g_xBlockSize( blockSize ),
+  g_yBlockSize( blockSize ),
+  g_zBlockSize( blockSize ),
+  rawPointerOffset( offset ),
+  inFileName( fileName )
+{
+	if ( padding < 0 || padding > 2 ) {
+		std::cout << "Unsupported padding\n";
+		return;
 	}
 
-	template <int nLogBlockSize, typename LVDTraits>
-	void RawToLVDConverter<nLogBlockSize, LVDTraits>::GetData(RawType* dest,
-		const RawType* src,
-		int width,
-		int height,
-		int depth,
-		int sw,
-		int sh,
-		int sd,
+	m_step = blockSize - 2 * m_padding;
+	m_blockDimension = { int( ysl::RoundUpDivide( xSize, m_step ) ), int( ysl::RoundUpDivide( ySize, m_step ) ), int( ysl::RoundUpDivide( zSize, m_step ) ) };
 
-		int xb,
-		int yb,
-		int zb,
+	std::cout << g_xSize << " " << g_ySize << " " << g_zSize << std::endl;
+	m_lvdDataSize = m_blockDimension * ysl::Vector3i{ blockSize, blockSize, blockSize };
 
-		int xbegin,
-		int ybegin,
-		int zbegin,
+	std::cout << "Information: " << std::endl;
+	std::cout << "inner block size: "
+			  << blockSize << " - 2 x "
+			  << m_padding << " = " << m_step << std::endl;
+	std::cout << "lvd block dimension: " << m_blockDimension << std::endl;
+	std::cout << "lvd data dimension: " << m_lvdDataSize << std::endl;
 
-		int xstep,
-		int ystep,
-		int zstep,
-		RawType fill)
-	{
-		for (int z = 0; z < sd; z++)
-			for (int y = 0; y < sh; y++)
-				for (int x = 0; x < sw; x++)
-				{
-					const int xOffset = xbegin + xb * xstep;
-					const int yOffset = ybegin + yb * ystep;
-					const int zOffset = zbegin + zb * zstep;
-					const int gx = x + xOffset, gy = y + yOffset, gz = z + zOffset;
-					const size_t blockIndex = x + y * (size_t)sw + z * (size_t)sw * (size_t)sh;
-					if (gx >= 0 && gx < width && gy >= 0 && gy < height && gz >= 0 && gz < depth)
-					{
-						const size_t linearIndex = (gx)+(gy)* std::size_t(width) + (gz)* width * std::size_t(height);
-						*(dest + blockIndex) = *(src + linearIndex);
-					}
-					else
-					{
-						*(dest + blockIndex) = fill;
-					}
-				}
+	const auto rawBytes = std::size_t( xSize ) * ySize * zSize * sizeof( RawType ) + rawPointerOffset;
+
+	if ( rawBytes == 0 ) {
+		throw std::runtime_error( "empty data" );
 	}
 
+	const auto lvdBytes = size_t( m_lvdDataSize.x ) * size_t( m_lvdDataSize.y ) * size_t( m_lvdDataSize.z ) * sizeof( RawType );
 
-	template <int nLogBlockSize, typename LVDTraits>
-	RawToLVDConverter<nLogBlockSize, LVDTraits>::RawToLVDConverter(const std::string& fileName, int xSize, int ySize,
-		int zSize, int padding, const std::string & outFileName, std::size_t offset) :
-		g_xSize(xSize),
-		g_ySize(ySize),
-		g_zSize(zSize),
-		g_emptyValue(0),
-		m_padding(padding),
-		g_xBlockSize(blockSize),
-		g_yBlockSize(blockSize),
-		g_zBlockSize(blockSize),
-		rawPointerOffset(offset)
-	{
-		if (padding < 0 || padding > 2)
-		{
-			std::cout << "Unsupported repeat\n";
-			return;
-		}
-
-		const auto blockedSize = blockSize - 2 * m_padding;
-		m_blockDimension = { int(ysl::RoundUpDivide(xSize, blockedSize)), int(ysl::RoundUpDivide(ySize, blockedSize)) , int(ysl::RoundUpDivide(zSize, blockedSize)) };
-		//m_blockDimension = {int(xSize / blockedSize), int(ySize / blockedSize), int(zSize / blockedSize)};
-
-		std::cout << g_xSize << " " << g_ySize << " " << g_zSize << std::endl;
-		m_dataSize = m_blockDimension * ysl::Vector3i{ blockSize, blockSize, blockSize };
-
-		m_step = blockSize - 2 * m_padding;
-
-		std::cout << "Information:" << std::endl;
-		std::cout << "block size:" << blockedSize << std::endl;
-		std::cout << "lvd block dimension:" << m_blockDimension << std::endl;
-		std::cout << "lvd data dimension: " << m_dataSize << std::endl;
-
-		const auto rawBytes = std::size_t(xSize) * ySize * zSize * sizeof(RawType) + rawPointerOffset;
-
-		if (rawBytes == 0)
-		{
-			throw std::runtime_error("empty data");
-		}
-
-
-
-		auto repo = ysl::LibraryReposity::GetLibraryRepo();
-		assert(repo);
-		repo->AddLibrary("ioplugin");
-
-		rawIO = ysl::Object::CreateObject<IPluginFileMap>("common.filemapio");
-		if (rawIO == nullptr)
-			throw std::runtime_error("can not load ioplugin");
-
-		rawIO->Open(fileName, rawBytes, FileAccess::Read, MapAccess::ReadOnly);
-
-		//rawIO = std::make_shared<WindowsFileMapping>(fileName,
-		//	rawBytes,
-		//	WindowsFileMapping::Read, 
-		//	WindowsFileMapping::ReadOnly);
-
-		rawPtr = rawIO->FileMemPointer(0, rawBytes);
-		if (!rawPtr)
-		{
-			throw std::runtime_error("raw file bad mapping");
-		}
-		const auto lvdBytes = size_t(m_dataSize.x) * size_t(m_dataSize.y) * size_t(m_dataSize.z) * sizeof(RawType);
-
-		lvdIO = ysl::Object::CreateObject<IPluginFileMap>("common.filemapio");
-		if (lvdIO == nullptr)
-			throw std::runtime_error("can not load ioplugin");
-
-		lvdIO->Open(outFileName, lvdBytes + LVD_HEADER_SIZE, FileAccess::ReadWrite, MapAccess::ReadWrite);
-		lvdPtr = lvdIO->FileMemPointer(0, lvdBytes + LVD_HEADER_SIZE);
-		if (!lvdPtr)
-		{
-			throw std::runtime_error("lvd file bad mapping");
-		}
+	m_lvdFile.open( outFileName, std::ios::binary );
+	if ( !m_lvdFile.is_open() ) {
+		throw std::runtime_error( "can not open lvd file" );
 	}
-
-	template <int nLogBlockSize, typename LVDTraits>
-	bool RawToLVDConverter<nLogBlockSize, LVDTraits>::convert()
-	{
-		// Allocate a buffer for block data with padding 
-
-		if (!lvdPtr)
-		{
-			std::cout << "Bad lvd data pointer\n";
-			return false;
-		}
-		Timer timer;
-		size_t curBlocks = 0;
-		//std::atomic_size_t curBlocks = 0;
-
-		auto const buf = lvdPtr + LVD_HEADER_SIZE;
-		g_emptyValue = 0;
-		const auto step = blockSize - 2 * m_padding;
-		const auto totalBlocks = m_blockDimension.Prod();
-		timer.start();
-		//#pragma omp parallel for
-		for (int zb = 0; zb < m_blockDimension.z; zb++)
-		{
-			
-			for (int yb = 0; yb < m_blockDimension.y; yb++)
-				for (int xb = 0; xb < m_blockDimension.x; xb++)
-				{
-
-					//	g_xOffset = -m_padding + xb * step;
-					//	g_yOffset = -m_padding + yb * step;
-					//	g_zOffset = -m_padding + zb * step;
-
-
-					const int blockIndex = xb + yb * m_blockDimension.x + zb * m_blockDimension.x * m_blockDimension.y;
-					//getData(buf + blockIndex * size_t(blockSize) * blockSize * blockSize,
-					//	rawPtr + rawPointerOffset,
-					//	blockSize,
-					//	blockSize,
-					//	blockSize,
-					//	xb,
-					//	yb,
-					//	zb);
-					GetData(buf + blockIndex * size_t(blockSize) * blockSize * blockSize,
-						rawPtr + rawPointerOffset,
-						g_xSize,
-						g_ySize,
-						g_zSize,
-						blockSize,
-						blockSize,
-						blockSize,
-						xb,
-						yb,
-						zb,
-						-m_padding,
-						-m_padding,
-						-m_padding,
-						m_step,
-						m_step,
-						m_step,
-						0);
-					++curBlocks;
-					//curBlocks++;
-					if (curBlocks % 100 == 0)
-					{
-						const float curPercent = curBlocks * 1.0 / totalBlocks;
-						if (curPercent == 0.f)
-							continue;
-						const size_t seconds = timer.eval_remaining_time(curPercent) / 1000000.0;
-						int hh = seconds / 3600;
-						int mm = (seconds - hh * 3600) / 60;
-						int ss = int(seconds) % 60;
-						printf("%d of %d complete, make up %.2f%%. Estimated Remaining Time: %02d:%02d:%02d\r", curPercent, hh, mm, ss);
-					}
-				}
-		}
-		printf("\n");
-		timer.stop();
-		const size_t seconds = timer.duration() / 1000000.0;
-		int hh = seconds / 3600;
-		int mm = (seconds - hh * 3600) / 60;
-		int ss = int(seconds) % 60;
-		//printf("Convertion Finished. Total Time:%02d:%02d:%02d\n",hh,mm,ss);
-		return true;
-	}
-
-
-	template <int nLogBlockSize, typename LVDTraits>
-	bool RawToLVDConverter<nLogBlockSize, LVDTraits>::save(const std::string& fileName)
-	{
-
-		const auto rep = std::to_string(m_padding), bSize = std::to_string(1 << nLogBlockSize);
-		const auto lvdBytes = size_t(m_dataSize.x) * size_t(m_dataSize.y) * size_t(m_dataSize.z) * sizeof(RawType);
-		constexpr auto logBlockSize = nLogBlockSize;
-
-		// 36 bytes in total
-
-		LVDHeader lvdHeader;
-		lvdHeader.magicNum = LVDTraits::MagicNumber;
-		lvdHeader.dataDim[0] = m_dataSize.x;
-		lvdHeader.dataDim[1] = m_dataSize.y;
-		lvdHeader.dataDim[2] = m_dataSize.z;
-		lvdHeader.padding = m_padding;
-		lvdHeader.blockLengthInLog = logBlockSize;
-
-		lvdHeader.originalDataDim[0] = m_blockDimension.x * ((1 << nLogBlockSize) - 2 * m_padding);
-		lvdHeader.originalDataDim[1] = m_blockDimension.y * ((1 << nLogBlockSize) - 2 * m_padding);
-		lvdHeader.originalDataDim[2] = m_blockDimension.z * ((1 << nLogBlockSize) - 2 * m_padding);
-
-		const auto p = lvdHeader.Encode();
-
-		std::cout << m_dataSize << " " <<
-			logBlockSize << " " <<
-			m_padding << " " <<
-			g_xSize << " " <<
-			g_ySize << " " <<
-			g_zSize << std::endl;
-
-		// Write lvd header
-		memcpy(lvdPtr, p, LVD_HEADER_SIZE);
-
-		std::cout << "writing .lvd file finished\n";
-		return true;
-	}
-
-
-
-	template<int nLogBlockSize, typename LVDTraits = LVDFileTraits>
-	class RawToLVDConverterEx
-	{
-		using RawType = unsigned char;
-		//int g_xOffset, g_yOffset, g_zOffset;
-		int g_xSize, g_ySize, g_zSize;
-		int m_step;
-		int g_xBlockSize, g_yBlockSize, g_zBlockSize;
-		RawType g_emptyValue = 0;
-		std::size_t rawPointerOffset;
-
-
-
-
-		void getData(RawType* dest,
-			const RawType* src,
-			size_t width,
-			size_t height,
-			size_t depth,
-			size_t xb,
-			size_t yb,
-			size_t zb) const;
-
-		static void GetData(RawType * dest,
-			const RawType * src, int width, int height, int depth,
-			int w,
-			int h,
-			int d,
-			int xb,
-			int yb,
-			int zb,
-			int xbegin,
-			int ybegin,
-			int cbegin,
-			int xstep,
-			int ystep,
-			int zstep,
-			RawType fill);
-
-
-		std::ifstream m_rawFile;
-		std::ofstream m_lvdFile;
-
-
-		ysl::Vector3i m_lvdDataSize;
-		ysl::Vector3i m_blockDimension;
-
-		std::unique_ptr<RawType[]> m_rawBuf;
-		std::shared_ptr<ysl::IPluginFileMap> lvdIO;
-		unsigned char * lvdPtr;
-		const int m_padding;
-		static constexpr auto blockSize = 1 << nLogBlockSize;
-		std::string inFileName;
-	public:
-		RawToLVDConverterEx(const std::string& fileName, int xSize, int ySize, int zSize, int repeat, const std::string & outFileName, std::size_t offset = 0);
-		auto DimensionInData()const { return m_lvdDataSize; }
-		auto DimensionInBlock()const { return m_blockDimension; }
-		void setBoundaryValue(RawType value) { g_emptyValue = value; }
-		bool convert();
-		bool save(const std::string& fileName);
-
-	};
-
-	template <int nLogBlockSize, typename LVDTraits>
-	void RawToLVDConverterEx<nLogBlockSize, LVDTraits>::getData(RawType* dest,
-		const RawType* src,
-		size_t width,
-		size_t height,
-		size_t depth,
-		size_t xb,
-		size_t yb,
-		size_t zb) const
-	{
-		//#pragma omp parallel for
-
-		for (int z = 0; z < depth; z++)
-			for (int y = 0; y < height; y++)
-				for (int x = 0; x < width; x++)
-				{
-					const int xOffset = -m_padding + xb * m_step;
-					const int yOffset = -m_padding + yb * m_step;
-					const int zOffset = -m_padding + zb * m_step;
-					const int gx = x + xOffset, gy = y + yOffset, gz = z + zOffset;
-					const size_t blockIndex = x + y * g_xBlockSize + z * g_xBlockSize * g_yBlockSize;
-					if (gx >= 0 && gx < g_xSize && gy >= 0 && gy < g_ySize && gz >= 0 && gz < g_zSize)
-					{
-						const size_t linearIndex = (gx)+(gy)* std::size_t(g_xSize) + (gz)* g_xSize * std::size_t(
-							g_ySize);
-						*(dest + blockIndex) = *(src + linearIndex);
-					}
-					else
-					{
-						*(dest + blockIndex) = g_emptyValue;
-					}
-				}
-	}
-
-	template <int nLogBlockSize, typename LVDTraits>
-	void RawToLVDConverterEx<nLogBlockSize, LVDTraits>::GetData(RawType* dest,
-		const RawType* src,
-		int width,
-		int height,
-		int depth,
-		int sw,
-		int sh,
-		int sd,
-
-		int xb,
-		int yb,
-		int zb,
-
-		int xbegin,
-		int ybegin,
-		int zbegin,
-
-		int xstep,
-		int ystep,
-		int zstep,
-		RawType fill)
-	{
-		for (int z = 0; z < sd; z++)
-			for (int y = 0; y < sh; y++)
-				for (int x = 0; x < sw; x++)
-				{
-					const int xOffset = xbegin + xb * xstep;
-					const int yOffset = ybegin + yb * ystep;
-					const int zOffset = zbegin + zb * zstep;
-					const int gx = x + xOffset, gy = y + yOffset, gz = z + zOffset;
-					const size_t blockIndex = x + y * (size_t)sw + z * (size_t)sw * (size_t)sh;
-					if (gx >= 0 && gx < width && gy >= 0 && gy < height && gz >= 0 && gz < depth)
-					{
-						const size_t linearIndex = (gx)+(gy)* std::size_t(width) + (gz)* width * std::size_t(height);
-						*(dest + blockIndex) = *(src + linearIndex);
-					}
-					else
-					{
-						*(dest + blockIndex) = fill;
-					}
-				}
-	}
-
-
-	template <int nLogBlockSize, typename LVDTraits>
-	RawToLVDConverterEx<nLogBlockSize, LVDTraits>::RawToLVDConverterEx(const std::string& fileName, int xSize, int ySize,
-		int zSize, int padding, const std::string & outFileName, std::size_t offset) :
-		g_xSize(xSize),
-		g_ySize(ySize),
-		g_zSize(zSize),
-		g_emptyValue(0),
-		m_padding(padding),
-		g_xBlockSize(blockSize),
-		g_yBlockSize(blockSize),
-		g_zBlockSize(blockSize),
-		rawPointerOffset(offset),
-		inFileName(fileName)
-	{
-		if (padding < 0 || padding > 2)
-		{
-			std::cout << "Unsupported repeat\n";
-			return;
-		}
-
-		const auto blockedSize = blockSize - 2 * m_padding;
-		m_blockDimension = { int(ysl::RoundUpDivide(xSize, blockedSize)), int(ysl::RoundUpDivide(ySize, blockedSize)) , int(ysl::RoundUpDivide(zSize, blockedSize)) };
-
-		std::cout << g_xSize << " " << g_ySize << " " << g_zSize << std::endl;
-		m_lvdDataSize = m_blockDimension * ysl::Vector3i{ blockSize, blockSize, blockSize };
-
-		m_step = blockSize - 2 * m_padding;
-
-		std::cout << "Information:" << std::endl;
-		std::cout << "block size:" << blockedSize << std::endl;
-		std::cout << "lvd block dimension:" << m_blockDimension << std::endl;
-		std::cout << "lvd data dimension: " << m_lvdDataSize << std::endl;
-
-		const auto rawBytes = std::size_t(xSize) * ySize * zSize * sizeof(RawType) + rawPointerOffset;
-
-		if (rawBytes == 0)
-		{
-			throw std::runtime_error("empty data");
-		}
-
-
-		const auto lvdBytes = size_t(m_lvdDataSize.x) * size_t(m_lvdDataSize.y) * size_t(m_lvdDataSize.z) * sizeof(RawType);
-
-		//auto repo = ysl::LibraryReposity::GetLibraryRepo();
-		//assert(repo);
-		//repo->AddLibrary("ioplugin");
-		//lvdIO = ysl::Object::CreateObject<IPluginFileMap>("common.filemapio");
-		//if (lvdIO == nullptr)
-		//	throw std::runtime_error("can not load ioplugin");
-		//lvdIO->Open(outFileName, lvdBytes + LVD_HEADER_SIZE, FileAccess::ReadWrite, MapAccess::ReadWrite);
-		//lvdPtr = lvdIO->FileMemPointer(0, lvdBytes + LVD_HEADER_SIZE);
-		//if (!lvdPtr)
-		//{
-		//	throw std::runtime_error("lvd file bad mapping");
-		//}
-
-		m_lvdFile.open(outFileName, std::ios::binary);
-		if(!m_lvdFile.is_open())
-		{
-			throw std::runtime_error("can not open lvd file");
-		}
-
-	}
-
-	template <int nLogBlockSize, typename LVDTraits>
-	bool RawToLVDConverterEx<nLogBlockSize, LVDTraits>::convert()
-	{
-
-		RawReaderIO rawReader(inFileName, Size3(g_xSize, g_ySize, g_zSize), sizeof(RawType));
-
-		struct Buffer
-		{
-			std::unique_ptr<RawType[]> buffer;
-			Size3 size;
-			int index;
-			std::condition_variable cond_notify_read_compute;
-			std::condition_variable cond_notify_write;
-			std::mutex mtx;
-			bool ready = false;
-			Buffer(const Size3 & size, int index) :size(size), index(index)
-			{
-				buffer.reset(new RawType[size.Prod() * sizeof(RawType)]);
-			}
-		};
-
-		Buffer readBuffer(Size3(g_xSize, g_ySize, blockSize), -1);
-		Buffer writeBuffer(Size3(m_lvdDataSize.x, m_lvdDataSize.y, blockSize), -1);
-
-		std::cout << "Total Read Task: " << m_blockDimension.z << std::endl;
-		std::cout << "Total Write Task: " << m_blockDimension.z << std::endl;
-
-
-
-		int coreNums = omp_get_num_procs();
-		std::cout << "Core Numbers:" << coreNums << std::endl;
-
-		Timer t;
-		t.start();
-
-		ThreadPool readThreadPool(1);
-
-		//readThreadPool.Start();
-
-
-		for (int i = 0; i < m_blockDimension.z; i++)
-		{
-			const int startz = (-m_padding + i * (blockSize - 2 * m_padding)) > 0 ? (-m_padding + i * (blockSize - 2 * m_padding)) : 0;
-			const Vec3i start(0, 0, startz);
-
-			const Size3 size(g_xSize, g_ySize,Clamp(g_zSize - startz, 0, blockSize));
-			//const Size3 size(g_xSize, g_ySize,i!=0?Clamp(g_zSize - startz, 0, blockSize):62);
-			//std::cout << size << std::endl;
-			std::atomic_size_t totalBlocks = 0;
-			readThreadPool.AppendTask([&rawReader,coreNums,
-				start,			// start position of the whole raw data
-				size,			// size of the sub region
-				i,		        //task id
-				this,
-				&totalBlocks,
-				&readBuffer,
-				&writeBuffer]
-				()
-				{
-					{
-						std::unique_lock<std::mutex> lk(readBuffer.mtx);
-						readBuffer.cond_notify_read_compute.wait(lk, [&readBuffer]() {return readBuffer.ready == false; });
-
-						rawReader.readRegion(start, size, (unsigned char*)readBuffer.buffer.get());
-						readBuffer.ready = true;		//flag
-
-
-						std::unique_lock<std::mutex> lk2(writeBuffer.mtx);
-						writeBuffer.cond_notify_read_compute.wait(lk2, [&writeBuffer]() {return writeBuffer.ready == false; });
-
-						const int offset = (i == 0) ? -m_padding : 0;
-
-#pragma omp parallel for
-						for (int yb = 0; yb < m_blockDimension.y; yb++)
-							for (int xb = 0; xb < m_blockDimension.x; xb++)
-							{
-
-								const int blockIndex = xb + yb * m_blockDimension.x;
-								GetData(writeBuffer.buffer.get() + blockIndex * size_t(blockSize) * blockSize * blockSize,
-									readBuffer.buffer.get(),
-									size.x,
-									size.y,
-									size.z,
-									blockSize,
-									blockSize,
-									blockSize,
-									xb,
-									yb,
-									0,
-									-m_padding,
-									-m_padding,
-									offset,
-									m_step,
-									m_step,
-									m_step,
-									0);
-								++totalBlocks;
-								printf("%10lld of %10lld complete.\r",totalBlocks.load(),m_blockDimension.Prod());
-							}
-
-						//Debug("Compute Task %d has been finished.", i);
-						// compute finished
-						readBuffer.ready = false;	// dirty, prepare for next read
-						writeBuffer.index = i;
-						writeBuffer.ready = true;	// ready to write
-					}
-					readBuffer.cond_notify_read_compute.notify_one();		// notify to read next section
-					writeBuffer.cond_notify_write.notify_one();				// notify to the write thread to write into the disk
-
-				});
-
-			//std::this_thread::sleep_for(std::chrono::milliseconds(500));
-		}
-
-		size_t totalBlocks = 0;
-		ThreadPool writeThreadPool(1);
-		//writeThreadPool.Start();
-		for (int i = 0; i < m_blockDimension.z; i++)
-		{
-			writeThreadPool.AppendTask([this,&totalBlocks,&t,
-				&writeBuffer]
-				()
-				{
-					{
-						std::unique_lock<std::mutex> lk(writeBuffer.mtx);
-						writeBuffer.cond_notify_write.wait(lk, [&writeBuffer] {return writeBuffer.ready == true; });
-						const auto bytes = (uint64_t)m_lvdDataSize.x * (uint64_t)m_lvdDataSize.y * (uint64_t)blockSize * sizeof(RawType);
-						///TODO:: write to file
-						m_lvdFile.seekp(LVD_HEADER_SIZE + writeBuffer.index*bytes, std::ios_base::beg);
-						std::cout << "Write "<<bytes<<" Byte(s) To Disk:\n";
-						Timer pt;
-						pt.start();
-						m_lvdFile.write((char*)writeBuffer.buffer.get(), bytes);
-						pt.stop();
-						std::cout << "Write To Disk Finished. Time:"<< pt.duration_to_seconds()<<"s.\n";
-						totalBlocks += m_blockDimension.x*m_blockDimension.y;
-
-						float curPercent = totalBlocks * 1.0 / m_blockDimension.Prod();
-						size_t seconds = t.eval_remaining_time(curPercent) / 1000000;
-						const int hh = seconds / 3600;
-						const int mm = (seconds - hh * 3600) / 60;
-						const int ss = int(seconds) % 60;
-						printf("%20lld blocks finished, made up %.2f%%. Estimated remaining time: %02d:%02d:%02d\n", totalBlocks, totalBlocks*100.0 / m_blockDimension.Prod(),hh,mm,ss);
-						writeBuffer.ready = false;		// prepare for next compute	
-					}
-					writeBuffer.cond_notify_read_compute.notify_one();			// notify to the read thread for the next read and computation
-				});
-			//std::this_thread::sleep_for(std::chrono::milliseconds(500));
-
-		}
-
-		//readThreadPool.Stop();
-		//writeThreadPool.Stop();
-		return true;
-	}
-
-
-	template <int nLogBlockSize, typename LVDTraits>
-	bool RawToLVDConverterEx<nLogBlockSize, LVDTraits>::save(const std::string& fileName)
-	{
-
-		const auto rep = std::to_string(m_padding), bSize = std::to_string(1 << nLogBlockSize);
-		const auto lvdBytes = size_t(m_lvdDataSize.x) * size_t(m_lvdDataSize.y) * size_t(m_lvdDataSize.z) * sizeof(RawType);
-		constexpr auto logBlockSize = nLogBlockSize;
-
-		// 36 bytes in total
-
-		LVDHeader lvdHeader;
-		lvdHeader.magicNum = LVDTraits::MagicNumber;
-		lvdHeader.dataDim[0] = m_lvdDataSize.x;
-		lvdHeader.dataDim[1] = m_lvdDataSize.y;
-		lvdHeader.dataDim[2] = m_lvdDataSize.z;
-		lvdHeader.padding = m_padding;
-		lvdHeader.blockLengthInLog = logBlockSize;
-
-		//lvdHeader.originalDataDim[0] = m_blockDimension.x * ((1 << nLogBlockSize) - 2 * m_padding);
-		//lvdHeader.originalDataDim[1] = m_blockDimension.y * ((1 << nLogBlockSize) - 2 * m_padding);
-		//lvdHeader.originalDataDim[2] = m_blockDimension.z * ((1 << nLogBlockSize) - 2 * m_padding);
-
-		lvdHeader.originalDataDim[0] = g_xSize;
-		lvdHeader.originalDataDim[1] = g_ySize;
-		lvdHeader.originalDataDim[2] = g_zSize;
-
-		const auto p = lvdHeader.Encode();
-
-		std::cout << m_lvdDataSize << " " <<
-			logBlockSize << " " <<
-			m_padding << " " <<
-			g_xSize << " " <<
-			g_ySize << " " <<
-			g_zSize << std::endl;
-
-		// Write lvd header
-		//auto header = lvdIO->FileMemPointer(0,LVD_HEADER_SIZE);
-		//if (!header)
-		//{
-		//	throw std::runtime_error("lvd file bad mapping in save()");
-		//}
-		//memcpy(header, p, LVD_HEADER_SIZE);
-		//lvdIO->DestroyFileMemPointer(header);
-		m_lvdFile.seekp(0, std::ios_base::beg);
-		m_lvdFile.write((char*)p, LVD_HEADER_SIZE);
-
-		std::cout << "writing .lvd file finished\n";
-		return true;
-	}
-
 }
 
-#endif/*_LVDCONVERTER_H_*/
+template <int nLogBlockSize, typename LVDTraits>
+bool RawToLVDConverterEx<nLogBlockSize, LVDTraits>::convert( std::size_t suggestMemGb )
+{
+	RawReaderIO rawReader( inFileName, Size3( g_xSize, g_ySize, g_zSize ), sizeof( RawType ) );
+
+	struct Buffer
+	{
+		std::unique_ptr<RawType[]> buffer;
+		std::pair<int, std::size_t> stride;
+		std::condition_variable cond_notify_read_compute;
+		std::condition_variable cond_notify_write;
+		std::mutex mtx;
+		bool ready = false;
+		Buffer( std::size_t nVoxels )
+		{
+			buffer.reset( new RawType[ nVoxels * sizeof( RawType ) ] );
+		}
+	};
+
+	const std::size_t nVoxelsPerBlock = std::size_t( blockSize ) * blockSize * blockSize;
+
+	const auto [ nCols, nRows, nSlices ] = m_blockDimension;
+
+	const auto [ nColsPerStride, nRowsPerStride, strideInterval ] = [&] {
+		std::size_t gbToBytes = std::size_t( 1024 ) /*Mb*/ * 1024 /*Kb*/ * 1024 /*Bytes*/;
+		std::size_t blockSizeInBytes = sizeof( RawType ) * nVoxelsPerBlock;
+		std::size_t memSizeInBytes = suggestMemGb * gbToBytes;
+		int nBlocksInMem = memSizeInBytes / blockSizeInBytes / 2 /*two buffers*/;
+		if ( not nBlocksInMem ) {
+			throw std::runtime_error( "total memory < block size" );
+		}
+		// const int maxBlocksPerStride = 2;
+		// nBlocksInMem = std::min( nBlocksInMem, maxBlocksPerStride );
+		int nRowsPerStride = std::min( nBlocksInMem / nCols, nRows );
+		int nColsPerStride = nCols;
+		int strideInterval = 1;
+		if ( not nRowsPerStride ) { /*nBlocksInMem < nBlocksPerRow*/
+			nRowsPerStride = 1;
+			nColsPerStride = nBlocksInMem;
+			strideInterval = ysl::RoundUpDivide( nCols, nColsPerStride );
+		}
+		return std::make_tuple( nColsPerStride, nRowsPerStride, strideInterval );
+	}();
+	const int nBlocksPerStride = nColsPerStride * nRowsPerStride;
+	std::cout << "Stride Size: "
+			  << nColsPerStride << " x "
+			  << nRowsPerStride << " = "
+			  << nBlocksPerStride << " Blocks(s)" << std::endl;
+
+	const int nRowIters =
+	  ysl::RoundUpDivide( nRows, nRowsPerStride );
+
+	std::cout << "Total Strides: "
+			  << nRowIters * strideInterval * nSlices << std::endl;
+
+	// since readBuffer is no larger than writeBuffer
+	const std::size_t bufferSize = nVoxelsPerBlock * nBlocksPerStride;
+	std::cout << "Allocing Buffers: "
+			  << bufferSize
+			  << " x 2 Byte(s) = "
+			  << bufferSize / 1024 /*Kb*/ / 1024 /*Mb*/
+			  << " Mb" << std::endl;
+	Buffer readBuffer( nVoxelsPerBlock * nBlocksPerStride );
+	Buffer writeBuffer( nVoxelsPerBlock * nBlocksPerStride );
+
+	Timer t;
+	t.start();
+
+	ThreadPool readThreadPool( 1 );
+	ThreadPool writeThreadPool( 1 );
+
+	std::size_t totalReadBlocks = 0;
+	std::size_t totalWriteBlocks = 0;
+
+	auto readTask = [&, this]( int slice, int it, int rep ) {
+		const Vec2i strideStart( rep * nColsPerStride, it * nRowsPerStride );
+		const Size2 strideSize(
+		  std::min( nCols - strideStart.x, nColsPerStride ),
+		  std::min( nRows - strideStart.y, nRowsPerStride ) );
+
+		/* left bottom corner of region, if padding > 0 this coord might be < 0 */
+		Vec3i regionStart(
+		  strideStart.x * m_step - m_padding,
+		  strideStart.y * m_step - m_padding,
+		  std::max( -m_padding + slice * m_step, 0 ) );
+		/* whole region size includes padding, might overflow */
+		Size3 regionSize(
+		  strideSize.x * m_step + m_padding * 2,
+		  strideSize.y * m_step + m_padding * 2,
+		  Clamp( g_zSize - regionStart.z, 0, blockSize ) );
+		auto rawRegionSize = regionSize;
+
+		/* overflow = bbbb -> -x,x,-y,y */
+		int overflow = 0;
+		/* region overflows: x1 > X */
+		if ( regionSize.x + regionStart.x > g_xSize ) {
+			regionSize.x = g_xSize - regionStart.x;
+			overflow |= 0b0100;
+		}
+		/* region overflows: y1 > Y */
+		if ( regionSize.y + regionStart.y > g_ySize ) {
+			regionSize.y = g_ySize - regionStart.y;
+			overflow |= 0b0001;
+		}
+		/* region overflows: x0 < 0, must be a padding */
+		if ( regionStart.x < 0 ) {
+			regionSize.x -= m_padding;
+			regionStart.x = 0;
+			overflow |= 0b1000;
+		}
+		/* region overflows: y0 < 0, must be a padding */
+		if ( regionStart.y < 0 ) {
+			regionSize.y -= m_padding;
+			regionStart.y = 0;
+			overflow |= 0b0010;
+		}
+
+		std::size_t dx = 0, dy = 0;
+		/* let x_i = first voxel of line i
+		   x_i = len * i
+		   -> x'_i = slen * i + dx? * 1 + slen * dy?*/
+		if ( overflow & 0b1000 ) {
+			dx = m_padding;
+		}
+		if ( overflow & 0b0010 ) {
+			dy = m_padding;
+		}
+
+		const int zoffset = ( slice == 0 ) ? -m_padding : 0;
+
+		{
+			std::unique_lock<std::mutex> lk( readBuffer.mtx );
+			readBuffer.cond_notify_read_compute.wait(
+			  lk, [&] { return not readBuffer.ready; } );
+
+			std::cout << "Read Stride: " << strideStart << " " << strideSize << std::endl;
+			std::cout << "Read Region: " << regionStart << " " << regionSize << std::endl;
+
+			/* always read region into buffer[0..] */
+			rawReader.readRegion(
+			  regionStart, regionSize, (unsigned char *)readBuffer.buffer.get() );
+			readBuffer.ready = true;  //flag
+
+			std::unique_lock<std::mutex> lk2( writeBuffer.mtx );
+			writeBuffer.cond_notify_read_compute.wait(
+			  lk2, [&] { return not writeBuffer.ready; } );
+
+			/* transfer overflowed into correct position */
+			if ( overflow ) {
+				memset( writeBuffer.buffer.get(), 0, sizeof( RawType ) * rawRegionSize.Prod() );
+				for ( int i = regionSize.y - 1; i >= 0; --i ) {
+					memcpy(
+					  writeBuffer.buffer.get() + rawRegionSize.x * ( i + dy ) + dx, /*x'_i*/
+					  readBuffer.buffer.get() + regionSize.x * i,					/*x_i*/
+					  regionSize.x * sizeof( RawType ) );
+				}
+				writeBuffer.buffer.swap( readBuffer.buffer );
+			}
+
+#           pragma omp parallel for
+			for ( int yb = 0; yb < strideSize.y; yb++ ) {
+				for ( int xb = 0; xb < strideSize.x; xb++ ) {
+					const int blockIndex = xb + yb * strideSize.x;
+					const auto destPtr = writeBuffer.buffer.get() +
+										 blockIndex * nVoxelsPerBlock;
+					const auto srcPtr = readBuffer.buffer.get() +
+										xb * m_step + yb * m_step * rawRegionSize.x;
+
+					for ( int row = 0; row < blockSize; ++row ) {
+						memcpy(
+						  destPtr + row * blockSize,
+						  srcPtr + row * rawRegionSize.x,
+						  blockSize * sizeof( RawType ) );
+					}
+					// z-offset
+
+					++totalReadBlocks;
+					printf( "%10lld of %10lld complete.\r", totalReadBlocks, m_blockDimension.Prod() );
+				}
+			}
+
+			// compute finished
+			readBuffer.ready = false;  // dirty, prepare for next read
+			writeBuffer.stride = std::make_pair(
+			  slice * m_blockDimension.x * m_blockDimension.y +
+				it * nCols * nRowsPerStride +
+				rep * nColsPerStride,
+			  strideSize.Prod() );
+			writeBuffer.ready = true;  // ready to write
+		}
+
+		readBuffer.cond_notify_read_compute.notify_one();  // notify to read next section
+		writeBuffer.cond_notify_write.notify_one();		   // notify to the write thread to write into the disk
+	};
+
+	auto writeTask = [&, this] {
+		{
+			std::unique_lock<std::mutex> lk( writeBuffer.mtx );
+			writeBuffer.cond_notify_write.wait( lk, [&] { return writeBuffer.ready; } );
+
+			const auto [ index, nBlocks ] = writeBuffer.stride;
+
+			const auto oneBlock = nVoxelsPerBlock * sizeof( RawType );
+			const auto offset = oneBlock * index;
+			const auto nBytes = oneBlock * nBlocks;
+			///TODO:: write to file
+			m_lvdFile.seekp( LVD_HEADER_SIZE + offset, std::ios_base::beg );
+			std::cout << "Write " << nBytes << " Byte(s) To Disk:\n";
+			Timer pt;
+			pt.start();
+			m_lvdFile.write( (char *)writeBuffer.buffer.get(), nBytes );
+			pt.stop();
+			std::cout << "Write To Disk Finished. Time:" << pt.duration_to_seconds() << "s.\n";
+			totalWriteBlocks += m_blockDimension.x * m_blockDimension.y;
+
+			float curPercent = totalWriteBlocks * 1.0 / m_blockDimension.Prod();
+			size_t seconds = t.eval_remaining_time( curPercent ) / 1000000;
+			const int hh = seconds / 3600;
+			const int mm = ( seconds - hh * 3600 ) / 60;
+			const int ss = int( seconds ) % 60;
+			printf( "%20lld blocks finished, made up %.2f%%. Estimated remaining time: %02d:%02d:%02d\n",
+					totalWriteBlocks, totalWriteBlocks * 100.0 / m_blockDimension.Prod(), hh, mm, ss );
+			writeBuffer.ready = false;  // prepare for next compute
+		}
+		writeBuffer.cond_notify_read_compute.notify_one();  // notify to the read thread for the next read and computation
+	};
+
+	for ( int slice = 0; slice < nSlices; slice++ ) {
+		for ( int it = 0; it < nRowIters; ++it ) {
+			for ( int rep = 0; rep < strideInterval; ++rep ) {
+				readThreadPool.AppendTask( readTask, slice, it, rep );
+				writeThreadPool.AppendTask( writeTask );
+			}
+		}
+	}
+
+	return true;
+}
+
+template <int nLogBlockSize, typename LVDTraits>
+bool RawToLVDConverterEx<nLogBlockSize, LVDTraits>::save()
+{
+	const auto rep = std::to_string( m_padding ), bSize = std::to_string( 1 << nLogBlockSize );
+	const auto lvdBytes = size_t( m_lvdDataSize.x ) * size_t( m_lvdDataSize.y ) * size_t( m_lvdDataSize.z ) * sizeof( RawType );
+	constexpr auto logBlockSize = nLogBlockSize;
+
+	// 36 bytes in total
+	LVDHeader lvdHeader;
+	lvdHeader.magicNum = LVDTraits::MagicNumber;
+	lvdHeader.dataDim[ 0 ] = m_lvdDataSize.x;
+	lvdHeader.dataDim[ 1 ] = m_lvdDataSize.y;
+	lvdHeader.dataDim[ 2 ] = m_lvdDataSize.z;
+	lvdHeader.padding = m_padding;
+	lvdHeader.blockLengthInLog = logBlockSize;
+
+	lvdHeader.originalDataDim[ 0 ] = g_xSize;
+	lvdHeader.originalDataDim[ 1 ] = g_ySize;
+	lvdHeader.originalDataDim[ 2 ] = g_zSize;
+
+	const auto p = lvdHeader.Encode();
+
+	std::cout << m_lvdDataSize << " " << logBlockSize << " " << m_padding << " " << g_xSize << " " << g_ySize << " " << g_zSize << std::endl;
+
+	m_lvdFile.seekp( 0, std::ios_base::beg );
+	m_lvdFile.write( (char *)p, LVD_HEADER_SIZE );
+
+	std::cout << "writing .lvd file finished\n";
+	return true;
+}
+
+}  // namespace ysl
+
+#endif /*_LVDCONVERTER_H_*/

--- a/src/common/object.h
+++ b/src/common/object.h
@@ -134,5 +134,50 @@ namespace ysl
 	};
 
 
+	template<typename Ty>
+	Ty* Object_Dynamic_Cast(Object * obj)
+	{
+		if (obj == nullptr)
+			return nullptr;
+		return Ty::_ms_RttiType.DerivedFrom(obj->GetRtti()) || obj->GetRtti().DerivedFrom(Ty::_ms_RttiType) ? static_cast<Ty*>(obj) : nullptr;
+	}
+
+	template<typename Ty>
+	const Ty* Object_Dynamic_Cast(const Object * obj)
+	{
+		if (obj == nullptr)
+			return nullptr;
+		return Ty::_ms_RttiType == (obj->GetRtti()) ? (Ty*)(obj) : nullptr;
+	}
+
+	template<typename Ty>
+	Ty * Object_Static_Cast(Object * obj)
+	{
+		return static_cast<Ty>(obj);
+	}
+
+	template<typename Ty>
+	const Ty * Object_Static_Cast(const Object * obj)
+	{
+		return static_cast<Ty>(obj);
+	}
+
+	//template<typename Ty>
+
+	template<typename Ty>
+	std::shared_ptr<Ty> Shared_Object_Dynamic_Cast(const std::shared_ptr<Object> &obj)
+	{
+		if (obj == nullptr)
+			return nullptr;
+		return Ty::_ms_RttiType == obj->GetRtti() ? std::static_pointer_cast<Ty>(obj) : nullptr;
+	}
+
+	template<typename Ty>
+	std::shared_ptr<Ty> Shared_Object_Static_Cast(const std::shared_ptr<Object> & obj)
+	{
+		return std::static_pointer_cast<Ty>(obj);
+	}
+
+
 }
 

--- a/src/common/virtualmemorymanager.h
+++ b/src/common/virtualmemorymanager.h
@@ -1,10 +1,12 @@
 
 #ifndef _VIRTUALMEMORYMANAGER_H_
 #define _VIRTUALMEMORYMANAGER_H_
+
 //#include "largevolumecache.h"
 #include "common.h"
 #include "geometry.h"
 #include <memory>
+#include <cstring>
 
 namespace ysl
 {

--- a/tools/lvdconverter/lvdconverter.cpp
+++ b/tools/lvdconverter/lvdconverter.cpp
@@ -3,12 +3,6 @@
 #include <lvdconverter.h>
 #include <cmdline.h>
 
-
-void convert()
-{
-
-}
-
 int main(int argc, char *argv[])
 {
 
@@ -18,8 +12,9 @@ int main(int argc, char *argv[])
 	a.add<int>("width", 'w', "width of the raw file", true);
 	a.add<int>("height", 'h', "height of the raw file", true);
 	a.add<int>("depth", 'd', "depth of the raw file", true);
+	a.add<int>("memlimit", 'm', "maximum memory limit in Gb", false, 128);
 	a.add<int>("padding",'p',"padding of the block, just support for 0, 1 or 2. the default value is 2", false, 2,cmdline::oneof<int>(0,1,2));
-	a.add<int>("side", 's', "the side length of the block, which is represented in logarithm, only support 5 ,6 and 7. The Default value is 6", false ,6,cmdline::oneof<int>(5,6,7));
+	a.add<int>("side", 's', "the side length of the block, which is represented in logarithm. The Default value is 6.", false, 6, cmdline::oneof<int>(5,6,7,8,9,10,11,12,13,14));
 	a.add<std::string>("of", 'f', ".lvd output filename", true);
 
 
@@ -37,36 +32,27 @@ int main(int argc, char *argv[])
 	auto repeat= a.get<int>("padding");
 	auto outFileName = a.get<std::string>("of");
 	auto log = a.get<int>("side");
+	
+#define IMPL_RAW_TO_LVD_LOG(N)											\
+	case N: {															\
+		ysl::RawToLVDConverterEx<N>										\
+			converter(fileName, x, y, z, repeat, outFileName, offset);	\
+		converter.convert();											\
+		converter.save();												\
+	} break
 
-
-	if (log == 5)
-	{
-		ysl::RawToLVDConverterEx<5> converter(fileName, x, y, z, repeat, outFileName, offset);
-		//ysl::RawToLVDConverter<6> converter(fileName, x, y, z, repeat, outFileName,offset);
-		converter.convert();
-		converter.save(fileName);
-	}
-	else if (log == 6)
-	{
-		ysl::RawToLVDConverterEx<6> converter(fileName, x, y, z, repeat, outFileName, offset);
-		//ysl::RawToLVDConverter<6> converter(fileName, x, y, z, repeat, outFileName,offset);
-		converter.convert();
-		converter.save(fileName);
-	}
-	else if (log == 7)
-	{
-		ysl::RawToLVDConverterEx<7> converter(fileName, x, y, z, repeat, outFileName, offset);
-		//ysl::RawToLVDConverter<7> converter(fileName, x, y, z, repeat, outFileName,offset);
-		converter.convert();
-		converter.save(fileName);
-	}
-	else
-	{
-		std::cout << "Unsupported block size\n";
+	switch (log) {
+	IMPL_RAW_TO_LVD_LOG(5);
+	IMPL_RAW_TO_LVD_LOG(6);
+	IMPL_RAW_TO_LVD_LOG(7);
+	IMPL_RAW_TO_LVD_LOG(8);
+	IMPL_RAW_TO_LVD_LOG(9);
+	IMPL_RAW_TO_LVD_LOG(10);
+	IMPL_RAW_TO_LVD_LOG(11);
+	IMPL_RAW_TO_LVD_LOG(12);
+	IMPL_RAW_TO_LVD_LOG(13);
+	IMPL_RAW_TO_LVD_LOG(14);
+	default: std::cout << "Unsupported block size\n";
 	}
 }
-
-
-
-
 


### PR DESCRIPTION
* move object-casting logic form `common.h` into `object.h`
* remove reference to comapi.h
* eliminate some warnings
* read multiple strides per slice if block size too large